### PR TITLE
Fix dataset restore logic in Stata code

### DIFF
--- a/Stata/i4results.ado
+++ b/Stata/i4results.ado
@@ -196,9 +196,11 @@ program define i4results, eclass
             export excel using "`out'", firstrow(variables) replace
             di as text "Exported results to Excel file: `out'"
         }
+        // Always restore the original dataset when writing to file
+        restore
     }
     else {
         di as text "Data with original & robustness comparisons is in memory."
+        // Keep results dataset in memory
     }
-restore
 end


### PR DESCRIPTION
## Summary
- keep results dataset in memory when no Excel output is specified
- only restore original dataset when exporting to Excel

## Testing
- `Codex couldn't run certain commands due to environnment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_684073d9d7a88321ae37d56de5e5005a