### PR TITLE
Add basic testthat structure and example test

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(i4results)
+
+test_check("i4results")

--- a/tests/testthat/test_i4results.R
+++ b/tests/testthat/test_i4results.R
@@ -1,0 +1,15 @@
+library(testthat)
+
+# Simple unit test for i4results function
+
+test_that("i4results handles lm models", {
+  skip_if_not_installed("i4results")
+  # fit original and robustness models
+  orig <- lm(mpg ~ wt, data = mtcars)
+  rob  <- list(rep1 = lm(mpg ~ wt + hp, data = mtcars))
+
+  res <- i4results(orig, rob)
+
+  expect_s3_class(res, "data.frame")
+  expect_true(all(c("paramname", "study", "o_coeff", "r_coeff") %in% colnames(res)))
+})


### PR DESCRIPTION
## Summary
- add `tests/testthat.R` and a simple test for `i4results`
- test fits lm models and checks returned data frame columns

## Testing
- `devtools::test()` *(fails: `R` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684079aa79e883219da15536fdf42612