### PR TITLE
Allow unlimited robustness models

### DIFF
--- a/R/R/i4results.R
+++ b/R/R/i4results.R
@@ -29,9 +29,7 @@ i4results <- function(original_model,
   if (!requireNamespace("broom", quietly = TRUE)) {
     stop("Package 'broom' needed for model extraction. Please install it.")
   }
-  if (length(robustness_models) > 5) {
-    stop("You can supply up to 5 robustness models only.")
-  }
+  ## Any number of robustness models can be compared
   
   ## ── Helper para garantizar columnas numéricas ──────────────────────────────
   safe_tidy <- function(model) {

--- a/R/man/i4results.Rd
+++ b/R/man/i4results.Rd
@@ -16,7 +16,7 @@ i4results(original_model, robustness_models, out = NULL, append = FALSE)
 A data frame (invisibly) with the combined original and robustness statistics.
 }
 \description{
-Exports side-by-side comparisons of coefficients from one original model and multiple robustness models. Uses \code{broom::tidy} so that many estimator types are supported. Results can optionally be written to Excel.
+Exports side-by-side comparisons of coefficients from one original model and any number of robustness models. Uses \code{broom::tidy} so that many estimator types are supported. Results can optionally be written to Excel.
 }
 \examples{
 \dontrun{

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # i4results
 
-Flexible **R** function _and_ **Stata** `ado` program that produce the side-by-side coefficient table required by the **Institute for Replication (I4R)**. Feed an *original* model plus up to five *robustness/replication* models and get a tidy long-format data set—ready for spreadsheets, dashboards, or reports.
+Flexible **R** function _and_ **Stata** `ado` program that produce the side-by-side coefficient table required by the **Institute for Replication (I4R)**. Feed an *original* model plus any number of *robustness/replication* models and get a tidy long-format data set—ready for spreadsheets, dashboards, or reports.
 
 ---
 


### PR DESCRIPTION
## Summary
- remove limit of five robustness models in `i4results()`
- mention unlimited models in docs

## Testing
- `R CMD check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68801da84a388321a63dd983049b2513